### PR TITLE
Allow using middle mouse button on bookmark

### DIFF
--- a/src/plugins/bookmarks/BookmarksDashboardView.tsx
+++ b/src/plugins/bookmarks/BookmarksDashboardView.tsx
@@ -5,10 +5,6 @@ export function BookmarksDashboardView({ config }: PluginComponentProps) {
   const bookmarksConfig = (config as unknown as BookmarksConfig) || { bookmarks: [] };
   const bookmarks = bookmarksConfig.bookmarks || [];
 
-  const handleBookmarkClick = (url: string) => {
-    window.location.href = url;
-  };
-
   if (bookmarks.length === 0) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground">
@@ -21,9 +17,9 @@ export function BookmarksDashboardView({ config }: PluginComponentProps) {
     <div className="p-3 grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-2 w-full">
       {bookmarks.map((bookmark, _) => {
         return (
-        <button
+        <a
           key={bookmark.id}
-          onClick={() => handleBookmarkClick(bookmark.url)}
+          href={bookmark.url}
           className="flex flex-col items-center gap-1 p-2 rounded-lg hover:bg-accent transition-colors group"
         >
           <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-card border border-border">
@@ -51,7 +47,7 @@ export function BookmarksDashboardView({ config }: PluginComponentProps) {
           <span className="text-xs text-center w-full leading-tight line-clamp-2 break-words">
             {bookmark.title}
           </span>
-        </button>
+        </a>
         );
       })}
     </div>


### PR DESCRIPTION
I have changed the button in the bookmark to an <a> tag. This is better because it uses an already existing solution for handling links and also handles things like using the middle mouse button to open the page in a new tab.

I have also removed the now redundant handleBookmarkClick function.