### PR TITLE
Allow Plugins to exit edit mode

### DIFF
--- a/src/components/Frame.tsx
+++ b/src/components/Frame.tsx
@@ -43,9 +43,11 @@ export function Frame({ frame, onDelete, onConfigChange, onNameChange, onNsfwTog
 
   const handleConfigChange = (config: Record<string, unknown>) => {
     onConfigChange(frame.id, config);
-    // Exit edit mode after saving configuration
-    setIsEditing(false);
   };
+
+  const handleExitEditMode = () => {
+    setIsEditing(false);
+  }
 
   const handleEditClick = (e: React.MouseEvent) => {
     e.preventDefault();
@@ -200,6 +202,7 @@ export function Frame({ frame, onDelete, onConfigChange, onNameChange, onNsfwTog
             config={frame.config}
             isEditing={isEditing}
             onConfigChange={handleConfigChange}
+            onExitEditMode={handleExitEditMode}
           />
         )}
       </div>

--- a/src/plugins/bookmarks/BookmarksEditView.tsx
+++ b/src/plugins/bookmarks/BookmarksEditView.tsx
@@ -123,7 +123,7 @@ function SortableBookmarkItem({ bookmark, onEdit, onDelete }: SortableBookmarkIt
   );
 }
 
-export function BookmarksEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function BookmarksEditView({ config, onConfigChange, isEditing, onExitEditMode }: PluginComponentProps) {
   const bookmarksConfig = (config as unknown as BookmarksConfig) || { bookmarks: [] };
   const bookmarks = bookmarksConfig.bookmarks || [];
   const [editingBookmark, setEditingBookmark] = useState<Bookmark | null>(null);
@@ -229,6 +229,9 @@ export function BookmarksEditView({ config, onConfigChange, isEditing }: PluginC
           onClose={() => {
             setEditingBookmark(null);
             setIsAdding(false);
+            if (bookmarks.length === 0) {
+              onExitEditMode();
+            }
           }}
           focusUrl={isAdding}
         />

--- a/src/plugins/finance/FinanceEditView.tsx
+++ b/src/plugins/finance/FinanceEditView.tsx
@@ -4,7 +4,7 @@ import { FinanceConfig } from './types';
 import { FinanceConfigModal } from './FinanceConfigModal';
 import { PluginComponentProps } from '@/types/plugin';
 
-export function FinanceEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function FinanceEditView({ config, onConfigChange, isEditing, onExitEditMode}: PluginComponentProps) {
   const financeConfig = (config as unknown as FinanceConfig) || {
     apiEndpoint: '',
     apiToken: '',
@@ -25,10 +25,12 @@ export function FinanceEditView({ config, onConfigChange, isEditing }: PluginCom
   const handleSave = (newConfig: FinanceConfig) => {
     onConfigChange(newConfig as unknown as Record<string, unknown>);
     setShowModal(false);
+    onExitEditMode();
   };
 
   const handleClose = () => {
     setShowModal(false);
+    onExitEditMode();
   };
 
   if (!showModal) {

--- a/src/plugins/googlecalendar/GoogleCalendarEditView.tsx
+++ b/src/plugins/googlecalendar/GoogleCalendarEditView.tsx
@@ -3,7 +3,7 @@ import { GoogleCalendarConfig } from './types';
 import { GoogleCalendarConfigModal } from './GoogleCalendarConfigModal';
 import { PluginComponentProps } from '@/types/plugin';
 
-export function GoogleCalendarEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function GoogleCalendarEditView({ config, onConfigChange, isEditing, onExitEditMode }: PluginComponentProps) {
   const googleCalendarConfig: GoogleCalendarConfig = {
     authType: (config as unknown as GoogleCalendarConfig)?.authType,
     accessToken: (config as unknown as GoogleCalendarConfig)?.accessToken,
@@ -24,10 +24,12 @@ export function GoogleCalendarEditView({ config, onConfigChange, isEditing }: Pl
   const handleSave = (newConfig: GoogleCalendarConfig) => {
     onConfigChange(newConfig as unknown as Record<string, unknown>);
     setShowModal(false);
+    onExitEditMode();
   };
 
   const handleClose = () => {
     setShowModal(false);
+    onExitEditMode();
   };
 
   if (!showModal) {

--- a/src/plugins/meteo/MeteoEditView.tsx
+++ b/src/plugins/meteo/MeteoEditView.tsx
@@ -3,7 +3,7 @@ import { PluginComponentProps } from '@/types/plugin';
 import { MeteoConfig } from './types';
 import { MeteoConfigModal } from './MeteoConfigModal';
 
-export function MeteoEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function MeteoEditView({ config, onConfigChange, isEditing, onExitEditMode }: PluginComponentProps) {
   const meteoConfig = (config as unknown as MeteoConfig) || {
     provider: 'openweather',
     apiKey: '',
@@ -20,10 +20,12 @@ export function MeteoEditView({ config, onConfigChange, isEditing }: PluginCompo
   const handleSave = (newConfig: MeteoConfig) => {
     onConfigChange(newConfig as unknown as Record<string, unknown>);
     setShowModal(false);
+    onExitEditMode();
   };
 
   const handleClose = () => {
     setShowModal(false);
+    onExitEditMode();
   };
 
   if (!showModal) {

--- a/src/plugins/tasktrove/TasktroveEditView.tsx
+++ b/src/plugins/tasktrove/TasktroveEditView.tsx
@@ -2,7 +2,7 @@ import { PluginComponentProps } from '@/types/plugin';
 import { TasktroveConfig } from './types';
 import { TasktroveConfigModal } from './TasktroveConfigModal';
 
-export function TasktroveEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function TasktroveEditView({ config, onConfigChange, isEditing, onExitEditMode }: PluginComponentProps) {
   const tasktroveConfig = (config as unknown as TasktroveConfig) || {
     apiEndpoint: '',
     apiToken: '',
@@ -19,14 +19,11 @@ export function TasktroveEditView({ config, onConfigChange, isEditing }: PluginC
 
   const handleSave = (newConfig: TasktroveConfig) => {
     onConfigChange(newConfig as unknown as Record<string, unknown>);
-    // isEditing will be set to false by Frame's handleConfigChange
+    onExitEditMode();
   };
 
   const handleClose = () => {
-    // When closing without saving, we need to exit edit mode
-    // We can do this by calling onConfigChange with the current config
-    // This will trigger handleConfigChange in Frame which sets isEditing to false
-    onConfigChange(tasktroveConfig as unknown as Record<string, unknown>);
+    onExitEditMode();
   };
 
   return (

--- a/src/plugins/youtrack/YoutrackEditView.tsx
+++ b/src/plugins/youtrack/YoutrackEditView.tsx
@@ -6,7 +6,7 @@ import { YoutrackConfigModal } from './YoutrackConfigModal';
 const DEFAULT_ISSUE_FIELDS = 'id,idReadable,created,updated,resolved,reporter(email),updater(email),commentsCount,tags(name),customFields($type,id,projectCustomField($type,id,field($type,id,name)),value($type,name,minutes,presentation)),summary,description';
 const DEFAULT_QUERY = '#Unresolved';
 
-export function YoutrackEditView({ config, onConfigChange, isEditing }: PluginComponentProps) {
+export function YoutrackEditView({ config, onConfigChange, isEditing, onExitEditMode }: PluginComponentProps) {
   const youtrackConfig = (config as unknown as YoutrackConfig) || {
     baseUrl: '',
     apiEndpoint: '',
@@ -27,10 +27,12 @@ export function YoutrackEditView({ config, onConfigChange, isEditing }: PluginCo
   const handleSave = (newConfig: YoutrackConfig) => {
     onConfigChange(newConfig as unknown as Record<string, unknown>);
     setShowModal(false);
+    onExitEditMode();
   };
 
   const handleClose = () => {
     setShowModal(false);
+    onExitEditMode();
   };
 
   if (!showModal) {

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -14,6 +14,7 @@ export interface PluginComponentProps {
   config: PluginConfig;
   isEditing: boolean;
   onConfigChange: (config: PluginConfig) => void;
+  onExitEditMode: () => void;
 }
 
 export interface Plugin {


### PR DESCRIPTION
This change gives the plugins' edit view the ability to close themselves.

Thanks to this change I could get rid of some weird workarounds like re-saving an unchanged config just so edit mode is toogled off. (see [TasktroveEditView.tsx](https://github.com/yawks/browser-newtab-dashboard/compare/main...MagicCheese1:stopEditFromPlugin?expand=1#diff-a1051fcb201594fa1acd70dfcd2c9f63bed2e8eb0b30766a0d8a611a65d8a3f8))

It also fixes a bug where you couldn't exit the bookmark modal without saving if you didn't have any bookmarks or weird behavior like the bookmark edit view exiting after every change or the edit view for other plugins staying enabled when the modal was closed without saving. 

please review this code to check if I missed anything and to see if I matched your naming style well.