### PR TITLE
disable editing when plugin is in nsfw mode

### DIFF
--- a/src/components/Frame.tsx
+++ b/src/components/Frame.tsx
@@ -154,6 +154,7 @@ export function Frame({ frame, onDelete, onConfigChange, onNameChange, onNsfwTog
             }`}
             title={isEditing ? 'View mode' : 'Edit mode'}
             type="button"
+            disabled={frame.isNsfw}
           >
             <Settings className="w-4 h-4" />
           </button>


### PR DESCRIPTION
When in nsfw mode, you could still press edit. The edit menu would then only show after disabling nsfw which i thought was weird and unexpected so I disabled it. The other solution would be to disable nsfw when edit is clicked. I think this is the nicer solution. 